### PR TITLE
New output structure and Fitter capabilities

### DIFF
--- a/interface/Fitter.h
+++ b/interface/Fitter.h
@@ -50,6 +50,7 @@ class Fitter {
 
   void fillResultContainers(bool fromImprov = false) ;
 
+  Double_t computeBoundaryDistance() ;
 
  public:
 
@@ -66,6 +67,7 @@ class Fitter {
   RooAbsReal* nll_penalty;
 
   Double_t boundDist;
+  Double_t boundDistTime;
 
   // lower threshold to parameters' uncertainties
   // to build the randomisation models (too small leads to many useless points)

--- a/interface/Fitter.h
+++ b/interface/Fitter.h
@@ -48,6 +48,9 @@ class Fitter {
   Double_t base4_corr;
   Double_t min_base;
 
+  void fillResultContainers(bool fromImprov = false) ;
+
+
  public:
 
   Double_t maxCoeff;
@@ -74,8 +77,11 @@ class Fitter {
   std::vector<Double_t> vFitResult;
   std::vector<Double_t> vFitErrLow;
   std::vector<Double_t> vFitErrHigh;
-  std::vector<Double_t> vConfInterLow;
-  std::vector<Double_t> vConfInterHigh;
+  std::vector<Double_t> vImprovResult;
+
+  std::vector<Double_t> vResult; /* Containing always the latest result, either from a fit or fit-improv */
+  std::vector<Double_t> vConfInterLow; /* Custom MINOS error */
+  std::vector<Double_t> vConfInterHigh; /* Custom MINOS error */
 
   Fitter() {} ; 
   Fitter(const char *_name, const char *_title,

--- a/plotMultiFit.cc
+++ b/plotMultiFit.cc
@@ -1,0 +1,453 @@
+#include <TFile.h>
+#include <TChain.h>
+#include <TCanvas.h>
+#include <TAxis.h>
+#include <TH1D.h>
+#include <TLine.h>
+
+using namespace std;
+
+static const int nBins = 8;
+float binBorders [nBins+1] = { 1, 2, 4.3, 6, 8.68, 10.09, 12.86, 14.18, 16};
+
+static const int nUncBins = 100;
+double binsUnc [nUncBins+1];
+
+static const int nPars = 8;
+string parName [nPars] = {"Fl","P1","P2","P3","P4p","P5p","P6p","P8p"};
+string parTitle[nPars] = {"F_{L}","P_{1}","P_{2}","P_{3}","P'_{4}","P'_{5}","P'_{6}","P'_{8}"};
+double parMin  [nPars] = {0,-1,-0.5,-0.5,-1*sqrt(2),-1*sqrt(2),-1*sqrt(2),-1*sqrt(2)};
+double parMax  [nPars] = {1, 1, 0.5, 0.5,   sqrt(2),   sqrt(2),   sqrt(2),   sqrt(2)};
+
+static const int nQuant = 4;
+double quantPerc [nQuant] = {0.025,0.16,0.84,0.975};
+
+int colors [12] = { 633, 417, 879, 857, 839, 801, 921, 607, 807, 419, 907, 402 };
+// int colors [13] = { 633, 417, 879, 857, 839, 887, 801, 921, 607, 807, 419, 907, 402 };
+
+double diffMax = 0.0499;
+
+void plotMultiFit (int binIndex=-1, int parity=1)
+{
+
+  vector< vector<TH1D*> > vHistBest (nPars);
+  vector< vector<TH1D*> > vHistErrH (nPars);
+  vector< vector<TH1D*> > vHistErrL (nPars);
+
+  vector< vector<double> > vHistBestRECO (nPars);
+  vector< vector<double> > vHistErrHRECO (nPars);
+  vector< vector<double> > vHistErrLRECO (nPars);
+
+  vector< vector<double> > vMean (nPars);
+  vector< vector<double> > vRMS  (nPars);
+  vector< vector<double> > vBias (nPars);
+  vector< vector<double> > vMeanErr (nPars);
+
+  vector<int> vq2Bins (0);
+
+  binsUnc[0]=0.006;
+  for (int i=0; i<nUncBins; ++i)
+    binsUnc[i+1] = binsUnc[i] * pow(0.4/binsUnc[0],1./nUncBins); // to reach 0.4 as largest error
+
+  double q2Val [nBins];
+  double q2Err [nBins];
+
+  for (int i=0; i<nBins; ++i) {
+    q2Val[i] = 0.5 * (binBorders[i+1]+binBorders[i]);
+    q2Err[i] = 0.5 * (binBorders[i+1]-binBorders[i]);
+  }
+
+  fstream fs ("../confSF/KDE_SF.list", fstream::in);
+  string fullLine = "";
+
+  int iColor = 0;
+
+  do {
+    getline(fs,fullLine);
+    if (fullLine.empty()) break;
+    cout<<"Running "<<fullLine<<endl;
+
+    stringstream ss(fullLine);
+    istream_iterator<string> begin(ss);
+    istream_iterator<string> end;
+    vector<string> splitLine(begin, end);
+
+    int q2Bin = atoi(splitLine[0].c_str());
+    if (binIndex>=0 && binIndex!=q2Bin) continue;
+    vq2Bins.push_back(q2Bin);
+
+    TChain fitResultsTree ("fitResultsTree","");
+    string filename = Form("simFitResults/simFitResult_recoMC_fullAngular201620172018_dataStat-*_b%i.root",q2Bin);
+    fitResultsTree.Add(filename.c_str());
+
+    string filename_fR = Form("simFitResults/simFitResult_recoMC_fullAngular201620172018_MCStat_b%i.root",q2Bin);
+    TFile* filein_fR = TFile::Open(filename_fR.c_str());
+    TTree* fitResultsTree_fR = (TTree*)filein_fR->Get("fitResultsTree");
+    if (!fitResultsTree_fR || fitResultsTree_fR->GetEntries() != 1) {
+      cout<<"Error, unexpected numebr of entries in fitResultsTree in file: "<<filename_fR<<endl;
+      return;
+    }
+
+    int nSamp = fitResultsTree.GetEntries();
+    cout<<"Number of samples: "<<nSamp<<endl;
+
+    vector<double> vBest(nPars);
+    vector<double> vHigh(nPars);
+    vector<double> vLow (nPars);
+
+    for (int iPar=0; iPar<nPars; ++iPar) {
+      
+      fitResultsTree.SetBranchAddress(Form("%s_best",parName[iPar].c_str()),&vBest[iPar]);
+      fitResultsTree.SetBranchAddress(Form("%s_high",parName[iPar].c_str()),&vHigh[iPar]);
+      fitResultsTree.SetBranchAddress(Form("%s_low" ,parName[iPar].c_str()),&vLow [iPar]);
+      
+      fitResultsTree_fR->SetBranchAddress(Form("%s_best",parName[iPar].c_str()),&vBest[iPar]);
+      fitResultsTree_fR->SetBranchAddress(Form("%s_high",parName[iPar].c_str()),&vHigh[iPar]);
+      fitResultsTree_fR->SetBranchAddress(Form("%s_low" ,parName[iPar].c_str()),&vLow [iPar]);
+
+      vHistBest[iPar].push_back( new TH1D(Form("hBest%i%i",q2Bin,iPar),Form("%s results of data-like MC sample fits - q2 bin %i;%s;# of results",parTitle[iPar].c_str(),q2Bin,parTitle[iPar].c_str()),100,parMin[iPar],parMax[iPar]) );
+      vHistErrH[iPar].push_back( new TH1D(Form("hErrH%i%i",q2Bin,iPar),Form("%s MINOS uncertainties of data-like MC sample fits - q2 bin %i;#sigma(%s);# of results",parTitle[iPar].c_str(),q2Bin,parTitle[iPar].c_str()),nUncBins,binsUnc) );
+      vHistErrL[iPar].push_back( new TH1D(Form("hErrL%i%i",q2Bin,iPar),Form("%s MINOS uncertainties of data-like MC sample fits - q2 bin %i;#sigma(%s);# of results",parTitle[iPar].c_str(),q2Bin,parTitle[iPar].c_str()),nUncBins,binsUnc) );
+
+      vHistBest[iPar].back()->SetLineColor(colors[iColor]);
+      vHistErrH[iPar].back()->SetLineColor(colors[iColor]);
+      vHistErrL[iPar].back()->SetLineColor(colors[iColor]);
+      vHistErrL[iPar].back()->SetFillColor(colors[iColor]);
+      vHistErrL[iPar].back()->SetFillStyle(3345);
+
+      vMean[iPar].push_back( 0 );
+      vRMS [iPar].push_back( 0 );
+      vBias[iPar].push_back( 0 );
+      vMeanErr[iPar].push_back( 0 );
+
+    }
+
+    fitResultsTree_fR->GetEntry(0);
+    for (int iPar=0; iPar<nPars; ++iPar) {
+      vHistBestRECO[iPar].push_back( vBest[iPar] );
+      vHistErrHRECO[iPar].push_back( vHigh[iPar] );
+      vHistErrLRECO[iPar].push_back( vLow [iPar] );
+    }
+
+    for (int iEn=0; iEn<fitResultsTree.GetEntries(); ++iEn) {
+      fitResultsTree.GetEntry(iEn);
+      for (int iPar=0; iPar<nPars; ++iPar) {
+	vHistBest[iPar].back()->Fill(vBest[iPar]);
+	vHistErrH[iPar].back()->Fill(vHigh[iPar]-vBest[iPar]);
+	vHistErrH[iPar].back()->Fill(vBest[iPar]-vLow [iPar]); // To create a stacked histogram
+	vHistErrL[iPar].back()->Fill(vBest[iPar]-vLow [iPar]);
+
+	vMean[iPar].back() += vBest[iPar];
+	vRMS[iPar].back() += vBest[iPar]*vBest[iPar];
+      }
+    }
+
+    for (int iPar=0; iPar<nPars; ++iPar) {
+      // cout<<vRMS[iPar].back()<<", "<<vBias[iPar].back()<<"("<<vBias[iPar].back() * vBias[iPar].back()<<") -> "<<( vRMS[iPar].back() - vBias[iPar].back() * vBias[iPar].back() ) / ( fitResultsTree.GetEntries() - 1 )<<endl;
+      vRMS[iPar].back() = sqrt( ( vRMS[iPar].back() - vMean[iPar].back() * vMean[iPar].back() / fitResultsTree.GetEntries() ) / ( fitResultsTree.GetEntries() - 1 ) );
+      vMean[iPar].back() = vMean[iPar].back() / fitResultsTree.GetEntries();
+      vBias[iPar].back() = vMean[iPar].back() - vHistBestRECO[iPar].back();
+      vMeanErr[iPar].back() = vRMS[iPar].back() / sqrt( fitResultsTree.GetEntries() );
+
+      printf("%s:\tBias (wrt RECO result) = %.5f\tRMS deviation: %.5f\n",parName[iPar].c_str(),vBias[iPar].back(),vRMS[iPar].back());
+    }
+
+  } while (++iColor);
+
+  int nPlotBins = vHistBestRECO[0].size();
+  if (nPlotBins<1) {
+    cout<<"ERROR, no q2 bins processed!"<<endl;
+    return;
+  }
+
+  gStyle->SetOptStat(0);
+
+  vector<TCanvas*> cDistr (nPars);
+  vector<TCanvas*> cUncert (nPars);
+  vector<TCanvas*> cResult (nPars);
+  vector< vector<TLine*> > lineRECO (nPars);
+  vector< vector<TLine*> > lineRMS (nPars);
+
+  for (int iPar=0; iPar<nPars; ++iPar) {
+
+    cDistr[iPar] = new TCanvas(Form("cDistr%i",iPar),Form("%s distribution",parTitle[iPar].c_str()),2000,1000);
+    cUncert[iPar] = new TCanvas(Form("cUncert%i",iPar),Form("%s uncertainty",parTitle[iPar].c_str()),2000,1000);
+    cResult[iPar] = new TCanvas(Form("cResult%i",iPar),Form("%s results",parTitle[iPar].c_str()),1000,1000);
+
+    cDistr[iPar]->cd();
+    vHistBest[iPar][0]->Draw();
+    double ymax = vHistBest[iPar][0]->GetMaximum();
+
+    cUncert[iPar]->cd()->SetLogx();
+    // copy underflow and overflow in first and last bins
+    vHistErrH[iPar][0]->AddBinContent(1,vHistErrH[iPar][0]->GetBinContent(0));
+    vHistErrL[iPar][0]->AddBinContent(1,vHistErrL[iPar][0]->GetBinContent(0));
+    vHistErrH[iPar][0]->AddBinContent(nUncBins,vHistErrH[iPar][0]->GetBinContent(nUncBins+1));
+    vHistErrL[iPar][0]->AddBinContent(nUncBins,vHistErrL[iPar][0]->GetBinContent(nUncBins+1));
+    vHistErrH[iPar][0]->GetXaxis()->SetMoreLogLabels();
+    vHistErrH[iPar][0]->Draw();
+    vHistErrL[iPar][0]->Draw("same");
+    double ymaxUnc = vHistErrH[iPar][0]->GetMaximum();
+
+    TLegend* leg;
+    TLegend* legUnc;
+    if ( parName[iPar].compare("P4p")==0 || parName[iPar].compare("P5p")==0 || parName[iPar].compare("P1")==0 )
+      leg = new TLegend(0.67,0.57,0.87,0.87,"q^{2} bin");
+    else
+      leg = new TLegend(0.15,0.57,0.35,0.87,"q^{2} bin");
+    if ( parName[iPar].compare("P4p")==0 || parName[iPar].compare("P8p")==0 || parName[iPar].compare("P3")==0 )
+      legUnc = new TLegend(0.15,0.57,0.35,0.87,"q^{2} bin");
+    else
+      legUnc = new TLegend(0.67,0.57,0.87,0.87,"q^{2} bin");
+    legUnc->SetNColumns(2);
+    if (nPlotBins>1) {
+      vHistBest[iPar][0]->SetTitle( Form("%s results of data-like MC sample fits",parTitle[iPar].c_str()) );
+      vHistErrH[iPar][0]->SetTitle( Form("%s MINOS uncertainties of data-like MC sample fits",parTitle[iPar].c_str()) );
+      leg->SetBorderSize(0);
+      leg->AddEntry(vHistBest[iPar][0],Form("%i [Bias:%.3f RMS:%.3f]",vq2Bins[0],vBias[iPar][0],vRMS[iPar][0]),"l");
+    }
+
+    legUnc->SetBorderSize(0);
+    legUnc->AddEntry(vHistErrH[iPar][0],Form("%i higher",vq2Bins[0]),"f");
+    legUnc->AddEntry(vHistErrL[iPar][0],Form("%i lower",vq2Bins[0]),"f");
+
+    for (int iBin=1; iBin<nPlotBins; ++iBin) {
+      cDistr[iPar]->cd();
+      vHistBest[iPar][iBin]->Draw("same");
+      if (ymax < vHistBest[iPar][iBin]->GetMaximum()) ymax = vHistBest[iPar][iBin]->GetMaximum();
+
+      cUncert[iPar]->cd();
+      vHistErrH[iPar][iBin]->AddBinContent(1,vHistErrH[iPar][iBin]->GetBinContent(0));
+      vHistErrL[iPar][iBin]->AddBinContent(1,vHistErrL[iPar][iBin]->GetBinContent(0));
+      vHistErrH[iPar][iBin]->AddBinContent(nUncBins,vHistErrH[iPar][iBin]->GetBinContent(nUncBins+1));
+      vHistErrL[iPar][iBin]->AddBinContent(nUncBins,vHistErrL[iPar][iBin]->GetBinContent(nUncBins+1));
+      vHistErrH[iPar][iBin]->Draw("same");
+      vHistErrL[iPar][iBin]->Draw("same");
+      if (ymaxUnc < vHistErrH[iPar][iBin]->GetMaximum()) ymaxUnc = vHistErrH[iPar][iBin]->GetMaximum();
+
+      leg   ->AddEntry(vHistBest[iPar][iBin],Form("%i [Bias:%.3f RMS:%.3f]",vq2Bins[iBin],vBias[iPar][iBin],vRMS[iPar][iBin]),"l");
+      legUnc->AddEntry(vHistErrH[iPar][iBin],Form("%i higher",vq2Bins[iBin]),"f");
+      legUnc->AddEntry(vHistErrL[iPar][iBin],Form("%i lower",vq2Bins[iBin]),"f");
+    }
+
+    vHistBest[iPar][0]->GetYaxis()->SetRangeUser(0,1.1*ymax);
+    vHistErrH[iPar][0]->GetYaxis()->SetRangeUser(0,1.1*ymaxUnc);
+
+    for (int iBin=0; iBin<nPlotBins; ++iBin) {
+      cDistr[iPar]->cd();
+      lineRECO[iPar].push_back( new TLine(vHistBestRECO[iPar][iBin],0,vHistBestRECO[iPar][iBin],1.1*ymax) );
+      lineRECO[iPar].back()->SetLineWidth(2);
+      lineRECO[iPar].back()->SetLineColor(colors[iBin]);
+      lineRECO[iPar].back()->Draw();
+
+      cUncert[iPar]->cd();
+      lineRMS[iPar].push_back( new TLine(vRMS[iPar][iBin],0,vRMS[iPar][iBin],1.1*ymaxUnc) );
+      lineRMS[iPar].back()->SetLineWidth(2);
+      lineRMS[iPar].back()->SetLineColor(colors[iBin]);
+      lineRMS[iPar].back()->Draw();
+    }
+
+    cDistr[iPar]->cd();
+    if (nPlotBins>1) leg->Draw();
+    cUncert[iPar]->cd();
+    legUnc->Draw();
+
+    cDistr[iPar]->SaveAs(Form("plotSimFit_d/simfit_recoMC_%s_dist.pdf",parName[iPar].c_str()));
+    cUncert[iPar]->SaveAs(Form("plotSimFit_d/simfit_recoMC_%s_uncert.pdf",parName[iPar].c_str()));
+
+    // Plot resutls vs q2
+
+    double aMean [nBins];
+    double aMeanErr [nBins];
+    double aReco [nBins];
+    double aRecoErrH [nBins];
+    double aRecoErrL [nBins];
+    double aBias [nBins];
+    double aBiasErrH [nBins];
+    double aBiasErrL [nBins];
+    double aQuantInnerCenter [nBins];
+    double aQuantOuterCenter [nBins];
+    double aQuantInnerError [nBins];
+    double aQuantOuterError [nBins];
+
+    if (nQuant<4) {
+      cout<<"Too few quantile values provided: "<<nQuant<<endl;
+      return;
+    }
+
+    for (int iBin=0; iBin<nBins; ++iBin) {
+     aMean[iBin] = -9;
+     aMeanErr[iBin] = 1;
+
+     aReco[iBin] = -9;
+     aRecoErrH[iBin] = 1;
+     aRecoErrL[iBin] = 1;
+
+     aBias[iBin] = -9;
+     aBiasErrH[iBin] = 1;
+     aBiasErrL[iBin] = 1;
+
+     aQuantInnerCenter[iBin] = -9;
+     aQuantOuterCenter[iBin] = -9;
+     aQuantInnerError[iBin] = 1;
+     aQuantOuterError[iBin] = 1;
+    }
+    for (int iBin=0; iBin<nPlotBins; ++iBin) {
+      aMean[vq2Bins[iBin]] = vMean[iPar][iBin];
+      aMeanErr[vq2Bins[iBin]] = vMeanErr[iPar][iBin];
+
+      aReco[vq2Bins[iBin]] = vHistBestRECO[iPar][iBin];
+      aRecoErrH[vq2Bins[iBin]] = vHistErrHRECO[iPar][iBin];
+      aRecoErrL[vq2Bins[iBin]] = vHistErrLRECO[iPar][iBin];
+
+      aBias[vq2Bins[iBin]] = vBias[iPar][iBin];
+      aBiasErrH[vq2Bins[iBin]] = sqrt( vMeanErr[iPar][iBin]*vMeanErr[iPar][iBin] + vHistErrLRECO[iPar][iBin]*vHistErrLRECO[iPar][iBin] );
+      aBiasErrL[vq2Bins[iBin]] = sqrt( vMeanErr[iPar][iBin]*vMeanErr[iPar][iBin] + vHistErrHRECO[iPar][iBin]*vHistErrHRECO[iPar][iBin] );
+
+      double quantVal[nQuant];
+      vHistBest[iPar][iBin]->GetQuantiles(nQuant,quantVal,quantPerc);
+      aQuantInnerCenter[vq2Bins[iBin]] = 0.5 * ( quantVal[1] + quantVal[2] );
+      aQuantOuterCenter[vq2Bins[iBin]] = 0.5 * ( quantVal[0] + quantVal[3] );
+      aQuantInnerError[vq2Bins[iBin]] = 0.5 * fabs( quantVal[1] - quantVal[2] );
+      aQuantOuterError[vq2Bins[iBin]] = 0.5 * fabs( quantVal[0] - quantVal[3] );
+    }
+
+
+    auto GrReco = new TGraphAsymmErrors(nBins, q2Val, aReco, q2Err, q2Err, aRecoErrL, aRecoErrH);
+    GrReco->SetName(Form("GrReco%i",iPar));
+    GrReco->SetTitle(Form("%s results from fit to data-like MC subsamples",parTitle[iPar].c_str()));
+    GrReco->GetYaxis()->SetTitle(parTitle[iPar].c_str());
+    auto Gr = new TGraphErrors(nBins, q2Val, aMean, q2Err, aMeanErr);
+    Gr->SetName(Form("Gr%i",iPar));    
+    auto GrDiff = new TGraphAsymmErrors(nBins, q2Val, aBias, q2Err, q2Err, aBiasErrL, aBiasErrH);
+    GrDiff->SetName(Form("GrDiff%i",iPar));
+    auto GrQuantIn = new TGraphErrors(nBins, q2Val, aQuantInnerCenter, q2Err, aQuantInnerError);
+    GrQuantIn->SetName(Form("GrQuantIn%i",iPar));    
+    auto GrQuantOut = new TGraphErrors(nBins, q2Val, aQuantOuterCenter, q2Err, aQuantOuterError);
+    GrQuantOut->SetName(Form("GrQuantOut%i",iPar));    
+
+    Gr->SetLineColor(kRed+1);
+    Gr->SetMarkerColor(kRed+1);
+    GrReco->SetLineColor(1);
+    GrReco->SetMarkerColor(1);
+    GrDiff->SetLineColor(1);
+    GrDiff->SetMarkerColor(1);
+    Gr->SetLineWidth(2);
+    GrReco->SetLineWidth(2);
+    GrDiff->SetLineWidth(2);
+
+    GrQuantIn->SetFillColor(38);
+    GrQuantOut->SetFillColor(38);
+    GrQuantOut->SetLineColor(38);
+    GrQuantOut->SetLineWidth(2);
+    GrQuantIn->SetFillStyle(3345);
+    GrQuantOut->SetFillStyle(0);
+
+    // Grey bands for resonant regions
+    double ResX [2] = {0.5*(binBorders[5]+binBorders[4]),0.5*(binBorders[7]+binBorders[6])};
+    double ResXe[2] = {0.5*(binBorders[5]-binBorders[4]),0.5*(binBorders[7]-binBorders[6])};
+    double ResY [2] = {0.5*(parMax[iPar]+parMin[iPar]),0.5*(parMax[iPar]+parMin[iPar])};
+    double ResYe[2] = {0.498*(parMax[iPar]-parMin[iPar]),0.498*(parMax[iPar]-parMin[iPar])};
+    double ResD [2] = {0,0};
+    double ResDe[2] = { 0.98*diffMax, 0.98*diffMax};
+    TGraphErrors *resCover = new TGraphErrors(2,ResX,ResY,ResXe,ResYe);
+    resCover->SetName(Form("resCover%i",iPar));
+    resCover->SetFillColor(18);
+    resCover->SetFillStyle(1001);
+    TGraphErrors *resDiffCover = new TGraphErrors(2,ResX,ResD,ResXe,ResDe);
+    resDiffCover->SetName(Form("resDiffCover%i",iPar));
+    resDiffCover->SetFillColor(18);
+    resDiffCover->SetFillStyle(1001);
+
+    // Legend
+    TLegend *legRes;
+    if (iPar==4 || iPar==5) legRes = new TLegend(0.15,0.65,0.4,0.85);
+    // else if (iPar==2) legRes = new TLegend(0.48,0.1,0.9,0.3);
+    else legRes = new TLegend(0.4,0.05,0.9,0.25);
+    legRes->SetName(Form("legRes%i",iPar));
+    legRes->SetBorderSize(0);
+    legRes->SetFillColor(1);
+    legRes->SetFillStyle(0);
+    legRes->SetTextSize(0.032);
+    legRes->AddEntry(GrReco,"Fit to full-MC sample","lep");
+    legRes->AddEntry(Gr,"Mean of fit to data-like MC samples","lep");
+    legRes->AddEntry(GrQuantIn,"Central 68\% of the results","f");
+    legRes->AddEntry(GrQuantOut,"Central 95\% of the results","f");
+
+    // Zero line
+    TLine *line = new TLine(GrReco->GetXaxis()->GetXmin(),0,GrReco->GetXaxis()->GetXmax(),0);
+    line->SetLineColor(14);
+    line->SetLineStyle(7);
+
+    cResult[iPar]->cd();
+    TPad *pad1 = new TPad(Form("pad1_%i",iPar), "pad1", 0, 0.3, 1, 1.0);
+    pad1->SetBottomMargin(0);
+    pad1->Draw();
+    pad1->cd();
+  
+     
+    GrReco->Draw("AP");
+
+    GrReco->GetYaxis()->SetLabelSize(0.);
+    GrReco->GetYaxis()->SetTitleSize(0.);
+    GrReco->GetYaxis()->SetRangeUser(parMin[iPar],parMax[iPar]);
+    TGaxis *axis = new TGaxis( GrReco->GetXaxis()->GetXmin(), parMin[iPar]+0.01,
+    			       GrReco->GetXaxis()->GetXmin(), parMax[iPar], 
+    			       parMin[iPar]+0.01,parMax[iPar], 
+    			       510, "");
+    axis->SetName(Form("axis%i",iPar));
+    axis->SetTitle(parTitle[iPar].c_str());
+    axis->SetLabelFont(43);
+    axis->SetLabelSize(20);
+    axis->Draw();
+
+    resCover->Draw("e2");
+    GrQuantOut->Draw("5");
+    GrQuantIn->Draw("2");
+    GrReco->Draw("P");
+    Gr-> Draw("P");    
+    legRes->Draw();
+
+    // plot difference wrt RECO results
+    cResult[iPar]->cd();
+    TPad *pad2 = new TPad(Form("pad2_%i",iPar), "pad2", 0, 0.05, 1, 0.3);
+    pad2->SetTopMargin(0);
+    pad2->SetBottomMargin(0.25);
+    pad2->Draw();
+    pad2->cd();
+
+    // first create axis
+    TH1F* auxE2 = new TH1F(Form("auxE2%i",iPar), "", nBins, GrReco->GetXaxis()->GetXmin(), GrReco->GetXaxis()->GetXmax());
+    auxE2->SetStats(kFALSE);
+    auxE2->SetLineColor(1);
+    auxE2->GetXaxis()->SetTitle("q^{2} (GeV^{2})");
+    auxE2->GetXaxis()->SetTitleSize(0.12);
+    auxE2->GetXaxis()->SetTitleOffset(0.95);
+    auxE2->GetXaxis()->SetLabelSize( 0.10);
+    auxE2->GetXaxis()->SetTickLength(0.1);
+    auxE2->GetYaxis()->SetTitle("Bias");
+    auxE2->GetYaxis()->SetTitleSize(0.10);
+    auxE2->GetYaxis()->SetTitleOffset(0.45);
+    auxE2->GetYaxis()->SetRangeUser(-1*diffMax,diffMax);
+    auxE2->GetYaxis()->SetLabelSize(0.07);
+    auxE2->GetYaxis()->SetNdivisions(505);
+    auxE2->Draw();
+
+    // Bin lines
+    std::vector<TLine*> lines;
+    for (int i=0; i<nBins-1; ++i) {
+      lines.push_back( new TLine(binBorders[i+1], -1*diffMax, binBorders[i+1], diffMax));
+      lines[i]->SetLineStyle(3);
+      lines[i]->SetLineColor(kGray);
+      lines[i]->Draw();
+    }
+  
+    GrDiff -> Draw("P");    
+    line->Draw();
+    resDiffCover->Draw("e2");
+
+    cResult[iPar]->SaveAs(Form("plotSimFit_d/simfit_recoMC_%s_results.pdf",parName[iPar].c_str()));
+
+  }
+
+}

--- a/run_simfit_recoMC_fullAngular.sh
+++ b/run_simfit_recoMC_fullAngular.sh
@@ -76,9 +76,15 @@ mkdir plotSimFit_d
 echo ./simfit_recoMC_fullAngular ${bin} ${par} ${multi} ${nsam} 1 ${plot} ${save} 2016 2017 2018
 ./simfit_recoMC_fullAngular ${bin} ${par} ${multi} ${nsam} 1 ${plot} ${save} 2016 2017 2018
 
+if [ ! -d $HOME/simFitResults ]; then
+    mkdir $HOME/simFitResults
+fi
+if [ ! -d $HOME/plotSimFit_d ]; then
+    mkdir $HOME/plotSimFit_d
+fi
 cp plotSimFit_d/* $HOME/plotSimFit_d/
-
-for file in simFitResults/* ; do cp $file $HOME/${file//.root/_${multi}s${nsam}.root}; done
+cp simFitResults/* $HOME/simFitResults/
+# for file in simFitResults/* ; do cp $file $HOME/${file//.root/_${multi}s${nsam}.root}; done
 
 rm -rf plotSimFit_d
 rm -rf simFitResults

--- a/simfit_recoMC_fullAngular.cc
+++ b/simfit_recoMC_fullAngular.cc
@@ -306,64 +306,32 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
   double boundDistFit, boundDist;
   bool boundCheck, convCheck, usedPenalty;
 
-  // RooRealVar* fitTime = new RooRealVar("fitTime","fit time",0,"s");
-  // RooRealVar* minTime = new RooRealVar("minTime","MINOS time",0,"s");
-  // RooRealVar* co1 = new RooRealVar("co1","Coefficient 1",0);
-  // RooRealVar* co4 = new RooRealVar("co4","Coefficient 4",0);
-  // RooRealVar* co5 = new RooRealVar("co5","Coefficient 5",0);
-  // RooRealVar* boundDist = new RooRealVar("boundDist","Distance from boundary",0);
   RooArgList pars (*Fl,*P1,*P2,*P3,*P4p,*P5p,*P6p,*P8p);
-  // RooArgSet savePars (*co1,*co4,*co5,*fitTime,*minTime,*boundDist);
-  // savePars.add(pars);
-  // RooCategory resStatus ("resStatus","Status of the fit result");
-  // resStatus.defineType("convergent-positive-noPenalty",0);
-  // resStatus.defineType("convergent-positive",1);
-  // resStatus.defineType("convergent-negative",2);
-  // resStatus.defineType("notconvergent-positive",3);
-  // resStatus.defineType("notconvergent-negative",4);
-  // RooDataSet* subResults = 0;
-  // RooDataSet* subNoPen = new RooDataSet("subNoPen","subNoPen",savePars);
-  // RooDataSet* subPosConv = new RooDataSet("subPosConv","subPosConv",savePars);
-  // RooDataSet* subPosNotc = new RooDataSet("subPosNotc","subPosNotc",savePars);
-  // RooDataSet* subNegConv = new RooDataSet("subNegConv","subNegConv",savePars);
-  // RooDataSet* subNegNotc = new RooDataSet("subNegNotc","subNegNotc",savePars);
 
   // TTree with fit output
   vector<double> vResult (pars.getSize());
   vector<double> vConfInterLow  (pars.getSize());
   vector<double> vConfInterHigh (pars.getSize());
   fout->cd();
-  // TTree* fitResultsTree = (TTree*)fout->Get("fitResultsTree");
-  // if (!fitResultsTree || fitResultsTree->IsZombie()) {
-  //   fitResultsTree = new TTree("fitResultsTree","fitResultsTree");
   TTree* fitResultsTree = new TTree("fitResultsTree","fitResultsTree");
-    for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-      RooRealVar* par = (RooRealVar*)pars.at(iPar);
-      fitResultsTree->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
-      fitResultsTree->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      fitResultsTree->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
-    }
-    fitResultsTree->Branch("fitTime",&fitTime);
-    fitResultsTree->Branch("imprTime",&imprTime);
-    fitResultsTree->Branch("minTime",&minTime);
-    fitResultsTree->Branch("co1",&co1);
-    fitResultsTree->Branch("co4",&co4);
-    fitResultsTree->Branch("co5",&co5);
-    fitResultsTree->Branch("boundDist",&boundDist);
-    fitResultsTree->Branch("boundDistFit",&boundDistFit);
-    fitResultsTree->Branch("boundCheck",&boundCheck);
-    fitResultsTree->Branch("convCheck",&convCheck);
-    fitResultsTree->Branch("usedPenalty",&usedPenalty);
+  for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
+    RooRealVar* par = (RooRealVar*)pars.at(iPar);
+    fitResultsTree->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
+    fitResultsTree->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
+    fitResultsTree->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
+  }
+  fitResultsTree->Branch("fitTime",&fitTime);
+  fitResultsTree->Branch("imprTime",&imprTime);
+  fitResultsTree->Branch("minTime",&minTime);
+  fitResultsTree->Branch("co1",&co1);
+  fitResultsTree->Branch("co4",&co4);
+  fitResultsTree->Branch("co5",&co5);
+  fitResultsTree->Branch("boundDist",&boundDist);
+  fitResultsTree->Branch("boundDistFit",&boundDistFit);
+  fitResultsTree->Branch("boundCheck",&boundCheck);
+  fitResultsTree->Branch("convCheck",&convCheck);
+  fitResultsTree->Branch("usedPenalty",&usedPenalty);
     
-  // } else {
-  //   for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-  //     RooRealVar* par = (RooRealVar*)pars.at(iPar);
-  //     fitResultsTree->SetBranchAddress(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
-  //     fitResultsTree->SetBranchAddress(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-  //     fitResultsTree->SetBranchAddress(Form("%s_best",par->GetName()),&vResult[iPar]);
-  //   }
-  // }
-
   // Timer for fitting time
   TStopwatch subTime;
 
@@ -431,15 +399,13 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
       convCheck = true;
       boundCheck = boundary->getValV() == 0;
 
-      // fitter->result()->SetName (Form("result_%s_subs%i",shortString.c_str(),is));
-      // fitter->result()->SetTitle(Form("result_%s_subs%i",shortString.c_str(),is));
       fitter->result()->Print("v");
 
       boundDistFit = boundDist = fitter->boundDist;
       usedPenalty = fitter->usedPenalty;
 	
       if (usedPenalty) {
-	// include coefficient values in dataset with per-toy informations
+	// save coefficient values
 	co1 = fitter->coeff1;
 	co4 = fitter->coeff4;
 	co5 = fitter->coeff5;
@@ -497,100 +463,29 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
     ++cnt[iCnt];
 
     // print fit status and time
-    if (!boundCheck) {
-      if (convCheck) {
-	// subNegConv->add(savePars);
-	cout<<"Converged in unphysical region";
-      } else {
-	// subNegNotc->add(savePars);
-	cout<<"Not converged";
-      }
-    } else {
-      if (convCheck) {
-	if (fitter->usedPenalty) {
-	  // subPosConv->add(savePars);
-	  cout<<"Converged with penalty term with coeff: "<<fitter->coeff1<<" "<<fitter->coeff4<<" "<<fitter->coeff5;
-	} else {
-	  // subNoPen->add(savePars);
-	  cout<<"Converged without penalty";
-	}
-      } else {
-	// subPosNotc->add(savePars);
-	cout<<"This should never be printed";
-      }
-    }
+    if (!boundCheck)
+      if (convCheck) cout<<"Converged in unphysical region";
+      else cout<<"Not converged";
+    else
+      if (convCheck)
+	if (fitter->usedPenalty) cout<<"Converged with penalty term with coeff: "<<fitter->coeff1<<" "<<fitter->coeff4<<" "<<fitter->coeff5;
+	else cout<<"Converged without penalty";
+      else cout<<"This should never be printed";
     cout<<" ("<<fitTime<<"s)"<<endl;
-
-    // Save fit results in file
-    // if (save && convCheck) {
-    //   fout->cd();
-    //   fitter->result()->Write(("simFitResult_"+shortString+ Form("subs%d",is)).c_str(),TObject::kWriteDelete);
-    // }
 
   }  
 
   if (multiSample) {
-    // subResults = new RooDataSet("subResults",
-    // 				"Results of RECO sub-sample fitting",
-    // 				savePars,Index(resStatus),
-    // 				Import("convergent-positive-noPenalty",*subNoPen),
-    // 				Import("convergent-positive",*subPosConv),
-    // 				Import("convergent-negative",*subNegConv),
-    // 				Import("notconvergent-positive",*subPosNotc),
-    // 				Import("notconvergent-negative",*subNegNotc));
-
-    // double time90quant = 0;
-    // double quant = 0;
-    // double totEntries = subResults->sumEntries();
-    // for (time90quant = 0; quant<0.9; time90quant += 0.1)
-    //   quant = subResults->sumEntries(Form("fitTime<%.2f",time90quant))/totEntries;
-    // cout<<"Average fit time: "<<subResults->mean(*fitTime)<<" sec (90% quantile: "<<time90quant<<" sec)"<<endl;
-
     cout<<"Fitted subsamples: "<<cnt[8]<<" of which good: "<<cnt[0]+cnt[1]<<" ("<<cnt[1]<<" with the use of the penalty term)"<<endl;
     cout<<"Bad fits: "<<cnt[3]<<" converging outside physical region, "<<cnt[5]+cnt[7]<<" not converged ("<<cnt[5]<<" in ph region)"<<endl;
   }
 
   if (save) {
-    // RooWorkspace* wksp = new RooWorkspace(((multiSample?"wsMulti_":"ws_")+shortString+Form("_s%i_pow%.1f",nSample,power)).c_str(),
-    // 					  (multiSample?"Workspace with set of RECO subsample fit results":
-    // 					   (nSample>0?"Workspace with RECO subsample fit result":
-    // 					    "Workspace with full RECO fit result")));
-
     fout->cd();
-
-    // for (auto iFit = vFitter.begin(); iFit != vFitter.end(); ++iFit)
-    // for (uint iFit = 0; iFit<vFitter.size(); ++iFit) {
-    //   wksp->import(*(vFitter[iFit]->GetData()));
-    //   wksp->Write();
-    // }
-
-    // if (multiSample) {
-    //   // wksp->import(*subResults);
-    // } else {
-    //   wksp->import(*combData,Rename("data"));
-    //   wksp->import(*simPdf,RenameVariable(simPdf->GetName(),"pdf"),Silence());
-    //   if (fitter->usedPenalty) {
-    // 	wksp->import(*simPdf_penalty,RenameVariable(simPdf_penalty->GetName(),"pdfPen"),Silence(),RecycleConflictNodes());
-    // 	wksp->import(*penTerm,Silence(),RecycleConflictNodes());
-    //   }
-
-    // }
-
     fitResultsTree->Write();
-
   }
 
   fout->Close();
-
-  // if (multiSample) {
-  //   TCanvas* cDist = new TCanvas (("cDist_"+shortString).c_str(),("cDist_"+shortString).c_str(),1800,1800);
-  //   RooPlot* fDist = boundDist->frame(Name("fDist"),Title("Distribution of results' distance fram boundary"),Range(0,0.1));
-  //   subNoPen->plotOn(fDist,Binning(50,0,0.1),LineColor(kBlue),MarkerColor(kBlue),MarkerStyle(19),DrawOption("XL"));
-  //   subPosConv->plotOn(fDist,Binning(50,0,0.1),LineColor(kRed),MarkerColor(kRed),MarkerStyle(19),DrawOption("XL"));
-  //   cDist->cd();
-  //   fDist->Draw();
-  //   cDist->SaveAs( ("plotSimFit_d/recoBoundDist_" + shortString + "_" + all_years + ".pdf").c_str() );
-  // }
 
   if (!plot || multiSample) return;
 

--- a/simfit_recoMC_fullAngular.cc
+++ b/simfit_recoMC_fullAngular.cc
@@ -291,7 +291,7 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
 
   if (nSample>0)   stat = stat + Form("-%i",firstSample);
   if (multiSample) stat = stat + Form("-%i",lastSample);
-  TFile* fout = new TFile(("simFitResults/simFitResult_recoMC_fullAngular" + all_years + stat + Form("_b%i.root", q2Bin)).c_str(),"UPDATE");
+  TFile* fout = new TFile(("simFitResults/simFitResult_recoMC_fullAngular" + all_years + stat + Form("_b%i.root", q2Bin)).c_str(),"RECREATE");
 
   // Construct combined dataset in (x,sample)
   RooDataSet allcombData ("allcombData", "combined data", 

--- a/simfit_recoMC_fullAngular.cc
+++ b/simfit_recoMC_fullAngular.cc
@@ -323,7 +323,7 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
   RooDataSet* subNegNotc = new RooDataSet("subNegNotc","subNegNotc",savePars);
 
   // TTree with the MINOS output
-  vector<double> vFitResult  (pars.getSize());
+  vector<double> vResult (pars.getSize());
   vector<double> vConfInterLow  (pars.getSize());
   vector<double> vConfInterHigh (pars.getSize());
   fout->cd();
@@ -334,14 +334,14 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->Branch(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   } else {
     for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->SetBranchAddress(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->SetBranchAddress(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   }
 
@@ -451,12 +451,12 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
 
 	// cout<<"Error difference [custMINOS - fit], lower and higher:"<<endl;
 	// for (int iPar = 0; iPar < pars.getSize(); ++iPar)
-	// 	cout<<vFitResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
-	// 	    <<vConfInterHigh[iPar]-vFitResult[iPar]-vFitErrHigh[iPar]<<endl;
+	// 	cout<<vResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
+	// 	    <<vConfInterHigh[iPar]-vResult[iPar]-vFitErrHigh[iPar]<<endl;
 
 	// save MINOS errors
 	for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-	  vFitResult[iPar] = fitter->vFitResult[iPar];
+	  vResult[iPar] = fitter->vResult[iPar];
 	  vConfInterLow[iPar] = fitter->vConfInterLow[iPar];
 	  vConfInterHigh[iPar] = fitter->vConfInterHigh[iPar];
 	}

--- a/simfit_recoMC_fullAngular.cc
+++ b/simfit_recoMC_fullAngular.cc
@@ -415,20 +415,13 @@ void simfit_recoMC_fullAngularBin(int q2Bin, int parity, bool multiSample, uint 
       fitter->result()->SetTitle(Form("result_%s_subs%i",shortString.c_str(),is));
       fitter->result()->Print("v");
 
+      boundDist->setVal(fitter->boundDist);
+	
       if (fitter->usedPenalty) {
 	// include coefficient values in dataset with per-toy informations
 	co1->setVal(fitter->coeff1);
 	co4->setVal(fitter->coeff4);
 	co5->setVal(fitter->coeff5);
-
-	// Compute distance from boundary, print it
-	// and save it in dataset with per-toy informations
-	TStopwatch distTime;
-	distTime.Start(true);
-	double boundDistVal = bound_dist->getValV();
-	distTime.Stop();
-	cout<<"Distance from boundary: "<<boundDistVal<<" (computed in "<<distTime.CpuTime()<<" s)"<<endl;
-	boundDist->setVal(boundDistVal);
 
 	TStopwatch improvTime;
 	improvTime.Start(true);

--- a/simfit_recoMC_fullAngular.sh
+++ b/simfit_recoMC_fullAngular.sh
@@ -2,15 +2,15 @@
 
 par=1
 
-multi=0
-nsam=${1}
+multi=${1}
+nsam=${2}
 
 plot=0
 save=1
 
 # Create directories for fit logs, results and plots
 if [ ! -d logs_simFit ]; then mkdir logs_simFit; fi
-if [ ! -d simFitResults/newphi ]; then mkdir -p simFitResults/newphi; fi
+if [ ! -d simFitResults ]; then mkdir -p simFitResults; fi
 if [ ! -d plotSimFit_d ]; then mkdir plotSimFit_d; fi
 
 # Compile dictionary and macro
@@ -23,12 +23,12 @@ if make simfit_recoMC_fullAngular; then
 	# for year in {2016..2018}; do
 	
 	#     ./simfit_recoMC_fullAngular ${bin} ${par} ${multi} ${nsam} 0 ${plot} ${save} ${year} \
-	# 	&>logs_simFit/simfit_recoMC_fullAngular_randLik_${bin}_${par}_${multi}_${nsam}_${year}.out &
+	# 	&>logs_simFit/simfit_recoMC_fullAngular_${bin}_${par}_${multi}_${nsam}_${year}.out &
 	
 	# done
 
 	./simfit_recoMC_fullAngular ${bin} ${par} ${multi} ${nsam} 0 ${plot} ${save} 2016 2017 2018 \
-	    &>logs_simFit/simfit_recoMC_fullAngular_randLik_${bin}_${par}_${multi}_${nsam}_2016_2017_2018.out &
+	    &>logs_simFit/simfit_recoMC_fullAngular_${bin}_${par}_${multi}_${nsam}_2016_2017_2018.out &
 
     done < ../confSF/KDE_SF.list
 

--- a/simfit_recoMC_fullAngularMass.cc
+++ b/simfit_recoMC_fullAngularMass.cc
@@ -430,7 +430,7 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
   RooDataSet* subNegNotc = new RooDataSet("subNegNotc","subNegNotc",savePars);
 
   // TTree with the MINOS output
-  vector<double> vFitResult  (pars.getSize());
+  vector<double> vResult  (pars.getSize());
   vector<double> vConfInterLow  (pars.getSize());
   vector<double> vConfInterHigh (pars.getSize());
   fout->cd();
@@ -441,14 +441,14 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->Branch(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   } else {
     for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->SetBranchAddress(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->SetBranchAddress(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   }
 
@@ -551,12 +551,12 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
 
 	// cout<<"Error difference [custMINOS - fit], lower and higher:"<<endl;
 	// for (int iPar = 0; iPar < pars.getSize(); ++iPar)
-	// 	cout<<vFitResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
-	// 	    <<vConfInterHigh[iPar]-vFitResult[iPar]-vFitErrHigh[iPar]<<endl;
+	// 	cout<<vResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
+	// 	    <<vConfInterHigh[iPar]-vResult[iPar]-vFitErrHigh[iPar]<<endl;
 
 	// save MINOS errors
 	for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-	  vFitResult[iPar] = fitter->vFitResult[iPar];
+	  vResult[iPar] = fitter->vResult[iPar];
 	  vConfInterLow[iPar] = fitter->vConfInterLow[iPar];
 	  vConfInterHigh[iPar] = fitter->vConfInterHigh[iPar];
 	}

--- a/simfit_recoMC_fullAngularMass.cc
+++ b/simfit_recoMC_fullAngularMass.cc
@@ -388,6 +388,8 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
   
   }
 
+  if (nSample>0)   stat = stat + Form("-%i",firstSample);
+  if (multiSample) stat = stat + Form("-%i",lastSample);
   TFile* fout = new TFile(("simFitResults4d/simFitResult_recoMC_fullAngularMass" + all_years + stat + Form("_b%i.root", q2Bin)).c_str(),"RECREATE");
   
   // save initial par values into a workspace 

--- a/simfit_recoMC_fullAngularMass.cc
+++ b/simfit_recoMC_fullAngularMass.cc
@@ -407,50 +407,36 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
   RooDataSet* combData = 0;
 
   // Results' containers
-  RooRealVar* fitTime = new RooRealVar("fitTime","fit time",0,"s");
-  RooRealVar* minTime = new RooRealVar("minTime","MINOS time",0,"s");
-  RooRealVar* co1 = new RooRealVar("co1","Coefficient 1",0);
-  RooRealVar* co4 = new RooRealVar("co4","Coefficient 4",0);
-  RooRealVar* co5 = new RooRealVar("co5","Coefficient 5",0);
-  RooRealVar* boundDist = new RooRealVar("boundDist","Distance from boundary",0);
+  double fitTime, imprTime, minTime;
+  double co1, co4, co5;
+  double boundDistFit, boundDist;
+  bool boundCheck, convCheck, usedPenalty;
+
   RooArgList pars (*Fl,*P1,*P2,*P3,*P4p,*P5p,*P6p,*P8p);
-  RooArgSet savePars (*co1,*co4,*co5,*fitTime,*minTime,*boundDist);
-  savePars.add(pars);
-  RooCategory resStatus ("resStatus","Status of the fit result");
-  resStatus.defineType("convergent-positive-noPenalty",0);
-  resStatus.defineType("convergent-positive",1);
-  resStatus.defineType("convergent-negative",2);
-  resStatus.defineType("notconvergent-positive",3);
-  resStatus.defineType("notconvergent-negative",4);
-  RooDataSet* subResults = 0;
-  RooDataSet* subNoPen = new RooDataSet("subNoPen","subNoPen",savePars);
-  RooDataSet* subPosConv = new RooDataSet("subPosConv","subPosConv",savePars);
-  RooDataSet* subPosNotc = new RooDataSet("subPosNotc","subPosNotc",savePars);
-  RooDataSet* subNegConv = new RooDataSet("subNegConv","subNegConv",savePars);
-  RooDataSet* subNegNotc = new RooDataSet("subNegNotc","subNegNotc",savePars);
 
   // TTree with the MINOS output
   vector<double> vResult  (pars.getSize());
   vector<double> vConfInterLow  (pars.getSize());
   vector<double> vConfInterHigh (pars.getSize());
   fout->cd();
-  TTree* MINOS_output = (TTree*)fout->Get("MINOS_output");
-  if (!MINOS_output || MINOS_output->IsZombie()) {
-    MINOS_output = new TTree("MINOS_output","MINOS_output");
-    for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-      RooRealVar* par = (RooRealVar*)pars.at(iPar);
-      MINOS_output->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
-      MINOS_output->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
-    }
-  } else {
-    for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-      RooRealVar* par = (RooRealVar*)pars.at(iPar);
-      MINOS_output->SetBranchAddress(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
-      MINOS_output->SetBranchAddress(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vResult[iPar]);
-    }
+  TTree* fitResultsTree = new TTree("fitResultsTree","fitResultsTree");
+  for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
+    RooRealVar* par = (RooRealVar*)pars.at(iPar);
+    fitResultsTree->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
+    fitResultsTree->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
+    fitResultsTree->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
   }
+  fitResultsTree->Branch("fitTime",&fitTime);
+  fitResultsTree->Branch("imprTime",&imprTime);
+  fitResultsTree->Branch("minTime",&minTime);
+  fitResultsTree->Branch("co1",&co1);
+  fitResultsTree->Branch("co4",&co4);
+  fitResultsTree->Branch("co5",&co5);
+  fitResultsTree->Branch("boundDist",&boundDist);
+  fitResultsTree->Branch("boundDistFit",&boundDistFit);
+  fitResultsTree->Branch("boundCheck",&boundCheck);
+  fitResultsTree->Branch("convCheck",&convCheck);
+  fitResultsTree->Branch("usedPenalty",&usedPenalty);
 
   // Timer for fitting time
   TStopwatch subTime;
@@ -497,38 +483,44 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
     int status = fitter->fit();
     subTime.Stop();
 
-    // include fit time in dataset with per-toy informations
-    fitTime->setVal(subTime.CpuTime());
-    // fitTime->setVal(subTime.RealTime());
+    fitTime=subTime.CpuTime();
+    cout<<"Fit+boundDist time: "<<fitTime<<endl;
 
-    co1->setVal(0);
-    co4->setVal(0);
-    co5->setVal(0);
-    boundDist->setVal(0);
-    minTime->setVal(0);
+    co1=0;
+    co4=0;
+    co5=0;
+    boundDist=0;
+    boundDistFit=0;
+    minTime=0;
 
-    bool convCheck = false;
-    bool boundCheck = false;
-
+    convCheck = false;
+    boundCheck = false;
 
     if (status==0) {
       
       convCheck = true;
       boundCheck = boundary->getValV() == 0;
 
-      fitter->result()->SetName (Form("result_%s_subs%i",shortString.c_str(),is));
-      fitter->result()->SetTitle(Form("result_%s_subs%i",shortString.c_str(),is));
       fitter->result()->Print("v");
 
-      boundDist->setVal(fitter->boundDist);
+      boundDistFit = boundDist = fitter->boundDist;
+      usedPenalty = fitter->usedPenalty;
 	
       if (fitter->usedPenalty) {
-	// include coefficient values in dataset with per-toy informations
-	co1->setVal(fitter->coeff1);
-	co4->setVal(fitter->coeff4);
-	co5->setVal(fitter->coeff5);
+	// save coefficient values
+	co1 = fitter->coeff1;
+	co4 = fitter->coeff4;
+	co5 = fitter->coeff5;
 
+	TStopwatch improvTime;
+	improvTime.Start(true);
 	fitter->improveAng();
+	improvTime.Stop();
+	imprTime = improvTime.CpuTime();
+	cout<<"Improv time: "<<imprTime<<" s"<<endl;
+
+	boundDist = fitter->boundDist;
+
       }
 
       if (nSample>0) {
@@ -539,22 +531,28 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
 	fitter->MinosAng();
 
 	minosTime.Stop();
-	minTime->setVal(minosTime.CpuTime());
-	cout<<"MINOS errors computed in "<<minosTime.CpuTime()<<" s"<<endl;
+	minTime = minosTime.CpuTime();
+	cout<<"MINOS errors computed in "<<minTime<<" s"<<endl;
 
 	// cout<<"Error difference [custMINOS - fit], lower and higher:"<<endl;
 	// for (int iPar = 0; iPar < pars.getSize(); ++iPar)
 	// 	cout<<vResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
 	// 	    <<vConfInterHigh[iPar]-vResult[iPar]-vFitErrHigh[iPar]<<endl;
 
-	// save MINOS errors
-	for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-	  vResult[iPar] = fitter->vResult[iPar];
+      }
+
+      // save results in tree
+      for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
+	vResult[iPar] = fitter->vResult[iPar];
+	if (nSample>0) {
 	  vConfInterLow[iPar] = fitter->vConfInterLow[iPar];
 	  vConfInterHigh[iPar] = fitter->vConfInterHigh[iPar];
+	} else {
+	  vConfInterLow[iPar] = fitter->vFitErrLow[iPar];
+	  vConfInterHigh[iPar] = fitter->vFitErrHigh[iPar];
 	}
-	MINOS_output->Fill();
       }
+      fitResultsTree->Fill();
 
     }
 
@@ -567,93 +565,30 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
     ++cnt[iCnt];
 
     // print fit status and time
-    if (!boundCheck) {
-      if (convCheck) {
-	subNegConv->add(savePars);
-	cout<<"Converged in unphysical region";
-      } else {
-	subNegNotc->add(savePars);
-	cout<<"Not converged";
-      }
-    } else {
-      if (convCheck) {
-	if (fitter->usedPenalty) {
-	  subPosConv->add(savePars);
-	  cout<<"Converged with penalty term with coeff: "<<fitter->coeff1<<" "<<fitter->coeff4<<" "<<fitter->coeff5;
-	} else {
-	  subNoPen->add(savePars);
-	  cout<<"Converged without penalty";
-	}
-      } else {
-	subPosNotc->add(savePars);
-	cout<<"This should never be printed";
-      }
-    }
-    cout<<" ("<<fitTime->getValV()<<"s)"<<endl;
-
-    // Save fit results in file
-    if (save && convCheck) {
-      fout->cd();
-      fitter->result()->Write(("simFitResult_"+shortString+ Form("subs%d",is)).c_str(),TObject::kWriteDelete);
-    }
+    if (!boundCheck)
+      if (convCheck) cout<<"Converged in unphysical region";
+      else cout<<"Not converged";
+    else
+      if (convCheck)
+	if (fitter->usedPenalty) cout<<"Converged with penalty term with coeff: "<<fitter->coeff1<<" "<<fitter->coeff4<<" "<<fitter->coeff5;
+	else cout<<"Converged without penalty";
+      else cout<<"This should never be printed";
+    cout<<" ("<<fitTime<<"s)"<<endl;
 
   }  
 
 
   if (multiSample) {
-    subResults = new RooDataSet("subResults",
-				"Results of RECO sub-sample fitting",
-				savePars,Index(resStatus),
-				Import("convergent-positive-noPenalty",*subNoPen),
-				Import("convergent-positive",*subPosConv),
-				Import("convergent-negative",*subNegConv),
-				Import("notconvergent-positive",*subPosNotc),
-				Import("notconvergent-negative",*subNegNotc));
-
-    double time90quant = 0;
-    double quant = 0;
-    double totEntries = subResults->sumEntries();
-    for (time90quant = 0; quant<0.9; time90quant += 0.1)
-      quant = subResults->sumEntries(Form("fitTime<%.2f",time90quant))/totEntries;
-    cout<<"Average fit time: "<<subResults->mean(*fitTime)<<" sec (90% quantile: "<<time90quant<<" sec)"<<endl;
-
     cout<<"Fitted subsamples: "<<cnt[8]<<" of which good: "<<cnt[0]+cnt[1]<<" ("<<cnt[1]<<" with the use of the penalty term)"<<endl;
     cout<<"Bad fits: "<<cnt[3]<<" converging outside physical region, "<<cnt[5]+cnt[7]<<" not converged ("<<cnt[5]<<" in ph region)"<<endl;
   }
 
   if (save) {
-    RooWorkspace* wksp = new RooWorkspace(((multiSample?"wsMulti_":"ws_")+shortString+Form("_s%i_pow%.1f",nSample,power)).c_str(),
-					  (multiSample?"Workspace with set of RECO subsample fit results":
-					   (nSample>0?"Workspace with RECO subsample fit result":
-					    "Workspace with full RECO fit result")));
-
-    if (multiSample) {
-      wksp->import(*subResults);
-    } else {
-      wksp->import(*combData,Rename("data"));
-      wksp->import(*simPdf,RenameVariable(simPdf->GetName(),"pdf"),Silence());
-      if (fitter->usedPenalty) {
-	wksp->import(*simPdf_penalty,RenameVariable(simPdf_penalty->GetName(),"pdfPen"),Silence(),RecycleConflictNodes());
-	wksp->import(*penTerm,Silence(),RecycleConflictNodes());
-      }
-    }
-
     fout->cd();
-    wksp->Write();
-    if (nSample>0) MINOS_output->Write();
+    fitResultsTree->Write();
   }
 
   fout->Close();
-
-  if (multiSample) {
-    TCanvas* cDist = new TCanvas (("cDist_"+shortString).c_str(),("cDist_"+shortString).c_str(),1800,1800);
-    RooPlot* fDist = boundDist->frame(Name("fDist"),Title("Distribution of results' distance fram boundary"),Range(0,0.1));
-    subNoPen->plotOn(fDist,Binning(50,0,0.1),LineColor(kBlue),MarkerColor(kBlue),MarkerStyle(19),DrawOption("XL"));
-    subPosConv->plotOn(fDist,Binning(50,0,0.1),LineColor(kRed),MarkerColor(kRed),MarkerStyle(19),DrawOption("XL"));
-    cDist->cd();
-    fDist->Draw();
-    cDist->SaveAs( ("plotSimFit_d/recoBoundDist_" + shortString + "_" + all_years + ".pdf").c_str() );
-  }
 
   if (!plot || multiSample) return;
 

--- a/simfit_recoMC_fullAngularMass.cc
+++ b/simfit_recoMC_fullAngularMass.cc
@@ -520,20 +520,13 @@ void simfit_recoMC_fullAngularMassBin(int q2Bin, int parity, bool multiSample, u
       fitter->result()->SetTitle(Form("result_%s_subs%i",shortString.c_str(),is));
       fitter->result()->Print("v");
 
+      boundDist->setVal(fitter->boundDist);
+	
       if (fitter->usedPenalty) {
 	// include coefficient values in dataset with per-toy informations
 	co1->setVal(fitter->coeff1);
 	co4->setVal(fitter->coeff4);
 	co5->setVal(fitter->coeff5);
-
-	// Compute distance from boundary, print it
-	// and save it in dataset with per-toy informations
-	TStopwatch distTime;
-	distTime.Start(true);
-	double boundDistVal = bound_dist->getValV();
-	distTime.Stop();
-	cout<<"Distance from boundary: "<<boundDistVal<<" (computed in "<<distTime.CpuTime()<<" s)"<<endl;
-	boundDist->setVal(boundDistVal);
 
 	fitter->improveAng();
       }

--- a/simfit_toy_fullAngular.cc
+++ b/simfit_toy_fullAngular.cc
@@ -399,21 +399,14 @@ void simfit_toy_fullAngularBin(int q2Bin, vector<double> genPars, uint seed, uin
       fitter->result()->SetTitle(Form("result_%s_subs%i",shortString.c_str(),is));
       fitter->result()->Print("v");
 
+      boundDist->setVal(fitter->boundDist);
+	
       if (fitter->usedPenalty) {
 	// include coefficient values in dataset with per-toy informations
 	co1->setVal(fitter->coeff1);
 	co4->setVal(fitter->coeff4);
 	co5->setVal(fitter->coeff5);
 
-	// Compute distance from boundary, print it
-	// and save it in dataset with per-toy informations
-	TStopwatch distTime;
-	distTime.Start(true);
-	double boundDistVal = bound_dist->getValV();
-	distTime.Stop();
-	cout<<"Distance from boundary: "<<boundDistVal<<" (computed in "<<distTime.CpuTime()<<" s)"<<endl;
-	boundDist->setVal(boundDistVal);
-	
 	TStopwatch improvTime;
 	improvTime.Start(true);
 	fitter->improveAng(seed);

--- a/simfit_toy_fullAngular.cc
+++ b/simfit_toy_fullAngular.cc
@@ -311,7 +311,7 @@ void simfit_toy_fullAngularBin(int q2Bin, vector<double> genPars, uint seed, uin
   RooDataSet* subNegNotc = new RooDataSet("subNegNotc","subNegNotc",savePars);
 
   // TTree with the MINOS output
-  vector<double> vFitResult  (pars.getSize());
+  vector<double> vResult  (pars.getSize());
   vector<double> vConfInterLow  (pars.getSize());
   vector<double> vConfInterHigh (pars.getSize());
   fout->cd();
@@ -322,14 +322,14 @@ void simfit_toy_fullAngularBin(int q2Bin, vector<double> genPars, uint seed, uin
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->Branch(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->Branch(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->Branch(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->Branch(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   } else {
     for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
       RooRealVar* par = (RooRealVar*)pars.at(iPar);
       MINOS_output->SetBranchAddress(Form("%s_low",par->GetName()),&vConfInterLow[iPar]);
       MINOS_output->SetBranchAddress(Form("%s_high",par->GetName()),&vConfInterHigh[iPar]);
-      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vFitResult[iPar]);
+      MINOS_output->SetBranchAddress(Form("%s_best",par->GetName()),&vResult[iPar]);
     }
   }
 
@@ -434,12 +434,12 @@ void simfit_toy_fullAngularBin(int q2Bin, vector<double> genPars, uint seed, uin
 
       // cout<<"Error difference [custMINOS - fit], lower and higher:"<<endl;
       // for (int iPar = 0; iPar < pars.getSize(); ++iPar)
-      // 	cout<<vFitResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
-      // 	    <<vConfInterHigh[iPar]-vFitResult[iPar]-vFitErrHigh[iPar]<<endl;
+      // 	cout<<vResult[iPar]-vConfInterLow[iPar]+vFitErrLow[iPar]<<"   \t"
+      // 	    <<vConfInterHigh[iPar]-vResult[iPar]-vFitErrHigh[iPar]<<endl;
 
       // save MINOS errors
       for (int iPar = 0; iPar < pars.getSize(); ++iPar) {
-	vFitResult[iPar] = fitter->vFitResult[iPar];
+	vResult[iPar] = fitter->vResult[iPar];
 	vConfInterLow[iPar] = fitter->vConfInterLow[iPar];
 	vConfInterHigh[iPar] = fitter->vConfInterHigh[iPar];
       }


### PR DESCRIPTION
Major changes:

- the output of the fit macros is simplified, moving from: MINOS tree + fit-performace dataset + fit-result workspace, to only a tree with fit/MINOS output and performance quantities
- the Fitter has a function to compute the distance from the boundary (useful to avoid many code repetitions)
- new macro to plot the results of a set of fits and compute RMS/bias wrt reference (useful for some systematic uncertainties). Here is an example of the output:

![simfit_recoMC_P5p_dist](https://user-images.githubusercontent.com/12882645/107394758-1b72b980-6af4-11eb-9b00-69b121b3eee0.png)
![simfit_recoMC_P5p_results](https://user-images.githubusercontent.com/12882645/107394764-1ca3e680-6af4-11eb-9254-0c5d19bb0e8b.png)
![simfit_recoMC_P5p_uncert](https://user-images.githubusercontent.com/12882645/107394769-1d3c7d00-6af4-11eb-9c4a-738e9b0a3b47.png)


