### PR TITLE
Unblinding changes circ pdfcut

### DIFF
--- a/interface/Fitter.h
+++ b/interface/Fitter.h
@@ -62,6 +62,8 @@ class Fitter {
 
   Bool_t printMinosScan;
 
+  Bool_t disableConstOpt;
+
   void fillResultContainers(bool fromImprov = false, bool isFree = false) ;
 
   Double_t computeBoundaryDistance() ;
@@ -148,6 +150,8 @@ class Fitter {
   void setUnbl(Int_t _unbl = 0) { unbl=_unbl; };
 
   void PrintMinosScan(Bool_t flag = true) { printMinosScan=flag; };
+
+  void DisableConstOpt(Bool_t flag = true) { disableConstOpt=flag; };
 
   ClassDef(Fitter,1) // Code to run the fit and statistical uncertainty
 };

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -261,8 +261,8 @@ RooGenericPdf* createPdfCuts(int q2Bin, int year, RooRealVar *var){
       }
 //      
      if(q2Bin==3)  expression = Form("(mass<%.5f)+(mass>%.5f)",m4[0],m1[0])+formula[0];
-     if(q2Bin==5)  expression = Form("(mass<%.5f)+(mass>%.5f)",m4[3],m1[3])+formula[3];
-     if(q2Bin==7)  expression = Form("(mass<%.5f)+(mass>%.5f)*(mass<%.5f)+(mass>%.5f)",m4[1],m1[1],m4[2],m1[2])+formula[1]+formula[2];
+     if(q2Bin==5)  expression = Form("(mass<%.5f)+(mass>%.5f)*(mass<%.5f)+(mass>%.5f)",m4[1],m1[1],m4[2],m1[2])+formula[1]+formula[2];
+     if(q2Bin==7)  expression = Form("(mass<%.5f)+(mass>%.5f)",m4[3],m1[3])+formula[3];
      std::cout<<Form("setting delatm for Era=%d => %f, %f, %f, %f",year,deltam[0],deltam[1],deltam[2],deltam[3])<<std::endl;
      std::cout<<Form("PdfCut expression defined for q2Bin=%i, year=%i as: %s",q2Bin,year,expression.c_str())<<std::endl;
      

--- a/simfit_data_fullAngularMass_Swave.cc
+++ b/simfit_data_fullAngularMass_Swave.cc
@@ -746,6 +746,9 @@ void simfit_data_fullAngularMass_SwaveBin(int q2Bin, int parity, bool multiSampl
       if (q2Bin==4) fitter->runSimpleFit = true;
     }
 
+    if (q2Bin==3 || q2Bin==5)
+      fitter->DisableConstOpt();
+
     subTime.Start(true);
     int status = fitter->fit();
     subTime.Stop();

--- a/simfit_data_fullAngularMass_Swave.cc
+++ b/simfit_data_fullAngularMass_Swave.cc
@@ -746,8 +746,10 @@ void simfit_data_fullAngularMass_SwaveBin(int q2Bin, int parity, bool multiSampl
       if (q2Bin==4) fitter->runSimpleFit = true;
     }
 
-    if (q2Bin==3 || q2Bin==5)
+    if (q2Bin==3 || q2Bin==5){
       fitter->DisableConstOpt();
+      std::cout<<Form("DisableConstOpt for q2Bin=%d",q2Bin)<<std::endl;
+    }  
 
     subTime.Start(true);
     int status = fitter->fit();

--- a/simfit_data_fullAngularMass_Swave.cc
+++ b/simfit_data_fullAngularMass_Swave.cc
@@ -242,6 +242,8 @@ void simfit_data_fullAngularMass_SwaveBin(int q2Bin, int parity, bool multiSampl
     if ( !effCHist[iy] || effCHist[iy]->IsZombie() || !effWHist[iy] || effWHist[iy]->IsZombie() ) {
       cout<<"Efficiency histogram "<< effCString <<" or " << effWString << " not found in file: "<< filename <<endl;
       return;
+    }else{
+      cout<<"Efficiency histogram "<< effCString <<" or " << effWString << " found in file: "<< filename <<endl;
     }
 
     // create efficiency functions
@@ -529,6 +531,8 @@ void simfit_data_fullAngularMass_SwaveBin(int q2Bin, int parity, bool multiSampl
     // in Jpsi bin, if fitOption > 0 -> bernstein polynbomial
     RooRealVar* slope = new RooRealVar(Form("slope^{%i}",years[iy]),  Form("slope^{%i}",years[iy]) , -5., -10., 0.);
     RooAbsPdf* bkg_mass_pdf = 0;
+    RooExponential* bkg_exp_pdf = 0;
+    RooGenericPdf* pdfCut = 0;
     double pol_bmax =1.;
     RooRealVar* b0_bkg_mass = new RooRealVar(Form("b0_bkg_mass-%i",years[iy]) , Form("b0_bkg_mass-%i",years[iy])  ,  pol_bmax  );
     RooRealVar* b1_bkg_mass = new RooRealVar(Form("b1_bkg_mass-%i",years[iy]) , Form("b1_bkg_mass-%i",years[iy])  ,  0.1,  0., pol_bmax);
@@ -540,7 +544,14 @@ void simfit_data_fullAngularMass_SwaveBin(int q2Bin, int parity, bool multiSampl
       b3_bkg_mass->setConstant(true);
       bkg_mass_pdf = new RooBernstein(Form("bkg_mass1_%i",years[iy]),Form("bkg_mass1_%i",years[iy]),  *mass, RooArgList(*b0_bkg_mass, *b1_bkg_mass, *b2_bkg_mass, *b3_bkg_mass,* b4_bkg_mass));
     } else { 
-      bkg_mass_pdf = new RooExponential(Form("bkg_mass1_%i",years[iy]),  Form("bkg_mass1_%i",years[iy]) ,  *mass,   *slope  );
+      bkg_exp_pdf = new RooExponential(Form("bkg_mass1_%i",years[iy]),  Form("bkg_mass1_%i",years[iy]) ,  *mass,   *slope  );
+      if (q2Bin==3||q2Bin==5) {
+       pdfCut = createPdfCuts(q2Bin,years[iy], mass);
+       bkg_mass_pdf= new RooProdPdf(Form("bkg_mass_pdf_%i",years[iy]),Form("bkg_mass_pdf_%i",years[iy]),RooArgSet(*bkg_exp_pdf,*pdfCut));
+      }else{
+       bkg_mass_pdf=bkg_exp_pdf;
+      } 
+       
     } 
 
     RooProdPdf* bkg_pdf = new RooProdPdf(Form(bkgpdfname.c_str(),years[iy]),

--- a/src/Fitter.cc
+++ b/src/Fitter.cc
@@ -141,6 +141,8 @@ void Fitter::SetDefConf()
 
   printMinosScan = false;
 
+  disableConstOpt = false;
+
 }
 
 
@@ -165,7 +167,8 @@ Int_t Fitter::fit()
     }                              
          
     RooMinimizer m(*nll) ;
-//    m.optimizeConst (kTRUE); // do not recalculate constant terms
+    if (!disableConstOpt)
+      m.optimizeConst (kTRUE); // do not recalculate constant terms
     m.setOffsetting(kTRUE);  //  Enable internal likelihood offsetting for enhanced numeric precision.
     // m.setVerbose(kTRUE);
     m.setPrintLevel(-1);

--- a/src/Fitter.cc
+++ b/src/Fitter.cc
@@ -165,7 +165,7 @@ Int_t Fitter::fit()
     }                              
          
     RooMinimizer m(*nll) ;
-    m.optimizeConst (kTRUE); // do not recalculate constant terms
+//    m.optimizeConst (kTRUE); // do not recalculate constant terms
     m.setOffsetting(kTRUE);  //  Enable internal likelihood offsetting for enhanced numeric precision.
     // m.setVerbose(kTRUE);
     m.setPrintLevel(-1);

--- a/src/RooBernsteinSideband.cxx
+++ b/src/RooBernsteinSideband.cxx
@@ -1,10 +1,17 @@
 /***************************************************************************** 
- * Project: RooBernsteinSideband                                                 * 
+ * Project: RooBernsteinSideband                                             * 
  *                                                                           * 
  * P.Dini fecit, Anno Domini MMXVIII                                         *
+ *                                                                           * 
  * "Est modus in rebus."                                                     * 
  *                                                                           * 
- * Class to describe 3D angular Sidebandciency in B0->K*MuMU Analysis            * 
+ * Class to describe 3D angular Sideband in B0->K*mumu Analysis              * 
+ *                                                                           * 
+ * Ipse mutavit, Anno Domini MMXXIV                                          * 
+ *                                                                           * 
+ * "Et de hoc satis"                                                         * 
+ *                                                                           * 
+ * Now with a trivial circularity condition added                            * 
  *                                                                           * 
  *****************************************************************************/ 
 
@@ -52,7 +59,7 @@ ClassImp(RooBernsteinSideband);
       int icc=0;
       for(int i = 0; i <= maxDegree1 ; ++i) {
      	for(int j = 0; j <= maxDegree2 ; ++j) {
-     	 for(int k = 0; k <= maxDegree3 ; ++k) {
+     	 for(int k = 0; k <  maxDegree3 ; ++k) {
  
      	 printf("RooBernsteinSideband: Par(%d)=%f cosL=%d cosK=%d phi=%d\n",icc,((RooAbsReal&) _coefList[icc]).getVal(), i,j,k);
      	 icc++;
@@ -141,6 +148,7 @@ Double_t RooBernsteinSideband::evaluate() const
 //       long double sz_div = 1.0/(1.0-z);
        
        int ipar =0;
+       int ipa0 =0;
        double func =0.0;
        double intg_1 =0.0;
        
@@ -164,10 +172,16 @@ Double_t RooBernsteinSideband::evaluate() const
 // 	   func += ((RooAbsReal&) _coefList[ipar-1]).getVal()*sx[_maxDegree1-i]*sy[_maxDegree2-j]*sz[_maxDegree3-k];
 //           intg_1 +=((RooAbsReal&) _coefList[ipar-1]).getVal();
 //	   if(fabs(((RooAbsReal&) _coefList[ipar]).getVal())>0.0){
+	    if (k==0) ipa0=ipar;
  	    bernknvalz =  device_coeffbinomial(_maxDegree3,k)*tz*sz[_maxDegree3-k];
- 	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
- 	    intg_1 += ((RooAbsReal&) _coefList[ipar]).getVal();
-	   ipar++;
+ 	    if(k==_maxDegree3){
+ 	     func   += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	     intg_1 += ((RooAbsReal&) _coefList[ipa0]).getVal();
+	    }else{
+ 	     func   += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	     intg_1 += ((RooAbsReal&) _coefList[ipar]).getVal();
+	     ipar++;
+	    } 
 // 	   } 
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) _coefList[ipar]).getVal()<<std::endl;
 	   tz *= z;
@@ -243,6 +257,7 @@ fptype  RooBernsteinSideband::device_bernsteinkn_func  (fptype x, fptype enne, f
 //    z=(z-zmin)/zdif;
     
        int ipar = 0 ;
+       int ipa0 =0;
        fptype ret   =0;
        fptype intg_1 =0.;
        for(int i = 0; i <= maxDegree1 ; ++i) {
@@ -250,13 +265,18 @@ fptype  RooBernsteinSideband::device_bernsteinkn_func  (fptype x, fptype enne, f
 //	  std::cout<<"func = par["<<ipar<<"]*x^"<<kk<<"*y^"<<jj<<std::endl;
           for(int k = 0; k <= maxDegree3 ; ++k) {
 //
+	   if (k==0) ipa0=ipar;
            fptype bernknintgbinx = device_SidebandBernsteinkn_intgBin(xLeft,xRight,maxDegree1,i);
            fptype bernknintgbiny = device_SidebandBernsteinkn_intgBin(yLeft,yRight,maxDegree2,j);
            fptype bernknintgbinz = device_SidebandBernsteinkn_intgBin(zLeft,zRight,maxDegree3,k);
-           ret   +=((RooAbsReal&) _coefList[ipar]).getVal()*bernknintgbinx*bernknintgbiny*bernknintgbinz;
-           intg_1+=((RooAbsReal&) _coefList[ipar]).getVal();
-//
-	   ipar++;
+ 	   if(k==maxDegree3){
+            ret   +=((RooAbsReal&) _coefList[ipa0]).getVal()*bernknintgbinx*bernknintgbiny*bernknintgbinz;
+            intg_1+=((RooAbsReal&) _coefList[ipa0]).getVal();
+ 	   }else{
+            ret   +=((RooAbsReal&) _coefList[ipar]).getVal()*bernknintgbinx*bernknintgbiny*bernknintgbinz;
+            intg_1+=((RooAbsReal&) _coefList[ipar]).getVal();
+	    ipar++;
+	   } 
 	  }
          }
        }
@@ -401,12 +421,14 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
        }
       }
          int ipar = 0 ;
+         int ipa0 =0;
          fptype ret   =0;
          for(int i = 0; i <= _maxDegree1 ; ++i) {
            for(int j = 0; j <= _maxDegree2 ; ++j) {
 //          std::cout<<"func = par["<<ipar<<"]*x^"<<kk<<"*y^"<<jj<<std::endl;
             for(int k = 0; k <= _maxDegree3 ; ++k) {
 
+	     if (k==0) ipa0=ipar;
 //              fptype bernknintgbinx = device_SidebandBernsteinkn_intgBin(xLeft,xRight,_maxDegree1,i);
 //              fptype bernknintgbiny = device_SidebandBernsteinkn_intgBin(yLeft,yRight,_maxDegree2,j);
 //              fptype bernknintgbinz = device_SidebandBernsteinkn_intgBin(zLeft,zRight,_maxDegree3,k);
@@ -414,9 +436,12 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
 //           fptype bernknintgbiny = 1./(maxDegree2+1.);
 //           fptype bernknintgbinz = 1./(maxDegree3+1.);
 //             ret   +=((RooAbsReal&) _coefList[ipar]).getVal()*bernknintgbinx*bernknintgbiny*bernknintgbinz;
-             ret   +=((RooAbsReal&) _coefList[ipar]).getVal()*bernknintgbinx[i]*bernknintgbiny[j]*bernknintgbinz[k];
- 
-             ipar++;
+	     if(k==_maxDegree3){
+              ret   +=((RooAbsReal&) _coefList[ipa0]).getVal()*bernknintgbinx[i]*bernknintgbiny[j]*bernknintgbinz[k];
+ 	     }else{
+              ret   +=((RooAbsReal&) _coefList[ipar]).getVal()*bernknintgbinx[i]*bernknintgbiny[j]*bernknintgbinz[k];
+              ipar++;
+	     } 
             }
  
  
@@ -457,18 +482,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sx[i]= sx[i-1]*(1.-x);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        fptype tx = 1.;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
          for(int j = 0; j <= _maxDegree2 ; ++j) {
           for(int k = 0; k <= _maxDegree3 ; ++k) {
 //           fptype bernknvalx =  device_bernsteinkn_func(x,_maxDegree1,i);
+	   if (k==0) ipa0=ipar;
            fptype bernknvalx =  device_coeffbinomial(_maxDegree1,i)*tx*sx[_maxDegree1-i];
  	   fptype bernknvaly =  device_SidebandBernsteinkn_intgBin(yLeft,yRight,_maxDegree2,j);
 	   fptype bernknvalz =  device_SidebandBernsteinkn_intgBin(zLeft,zRight,_maxDegree3,k);
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   }
 	  }
          }
 	 tx*=x;
@@ -483,18 +514,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sy[i]= sy[i-1]*(1.-y);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
          fptype ty = 1.;
          for(int j = 0; j <= _maxDegree2 ; ++j) {
           for(int k = 0; k <= _maxDegree3 ; ++k) {
+	   if (k==0) ipa0=ipar;
  	   fptype bernknvalx =  device_SidebandBernsteinkn_intgBin(xLeft,xRight,_maxDegree1,i);
 //           fptype bernknvaly =  device_bernsteinkn_func(y,_maxDegree2,j);
            fptype bernknvaly =  device_coeffbinomial(_maxDegree2,j)*ty*sy[_maxDegree2-j];
 	   fptype bernknvalz =  device_SidebandBernsteinkn_intgBin(zLeft,zRight,_maxDegree3,k);
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   } 
 	  }
 	  ty*=y;
          }
@@ -508,18 +545,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sz[i]= sz[i-1]*(1.-z);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
          for(int j = 0; j <= _maxDegree2 ; ++j) {
 	  fptype tz=1.;
           for(int k = 0; k <= _maxDegree3 ; ++k) {
+	   if (k==0) ipa0=ipar;
  	   fptype bernknvalx =  device_SidebandBernsteinkn_intgBin(xLeft,xRight,_maxDegree1,i);
  	   fptype bernknvaly =  device_SidebandBernsteinkn_intgBin(yLeft,yRight,_maxDegree2,j);
 //           fptype bernknvalz =  device_bernsteinkn_func(z,_maxDegree3,k);
            fptype bernknvalz =  device_coeffbinomial(_maxDegree3,k)*tz*sz[_maxDegree3-k];
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   } 
 	   tz*=z;
 	  }
          }
@@ -538,18 +581,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sz[i]= sz[i-1]*(1.-z);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
 	 fptype ty=1.;
          for(int j = 0; j <= _maxDegree2 ; ++j) {
 	  fptype tz=1.;
           for(int k = 0; k <= _maxDegree3 ; ++k) {
+	   if (k==0) ipa0=ipar;
  	   fptype bernknvalx =  device_SidebandBernsteinkn_intgBin(xLeft,xRight,_maxDegree1,i);
            fptype bernknvaly =  device_coeffbinomial(_maxDegree2,j)*ty*sy[_maxDegree2-j];
            fptype bernknvalz =  device_coeffbinomial(_maxDegree3,k)*tz*sz[_maxDegree3-k];
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   } 
 	   tz*=z;
 	  }
 	  ty*=y;
@@ -569,18 +618,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sz[i]= sz[i-1]*(1.-z);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        fptype tx=1.;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
          for(int j = 0; j <= _maxDegree2 ; ++j) {
 	  fptype tz=1.;
           for(int k = 0; k <= _maxDegree3 ; ++k) {
+	   if (k==0) ipa0=ipar;
            fptype bernknvalx =  device_coeffbinomial(_maxDegree1,i)*tx*sx[_maxDegree1-i];
  	   fptype bernknvaly =  device_SidebandBernsteinkn_intgBin(yLeft,yRight,_maxDegree2,j);
            fptype bernknvalz =  device_coeffbinomial(_maxDegree3,k)*tz*sz[_maxDegree3-k];
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   } 
 	   tz*=z;
 	  }
          }
@@ -600,18 +655,24 @@ Double_t RooBernsteinSideband::analyticalIntegral(Int_t code, const char* rangeN
         sy[i]= sy[i-1]*(1.-y);
        }
        int ipar =0;
+       int ipa0 =0;
        fptype func =0.0;
        fptype tx=1.;
        for(int i = 0; i <= _maxDegree1 ; ++i) {
 	 fptype ty=1.;
          for(int j = 0; j <= _maxDegree2 ; ++j) {
           for(int k = 0; k <= _maxDegree3 ; ++k) {
+	   if (k==0) ipa0=ipar;
            fptype bernknvalx =  device_coeffbinomial(_maxDegree1,i)*tx*sx[_maxDegree1-i];
            fptype bernknvaly =  device_coeffbinomial(_maxDegree2,j)*ty*sy[_maxDegree2-j];
  	   fptype bernknvalz =  device_SidebandBernsteinkn_intgBin(zLeft,zRight,_maxDegree3,k);
-	   func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+	   if(k==_maxDegree3){
+	    func += ((RooAbsReal&) _coefList[ipa0]).getVal()*bernknvalx*bernknvaly*bernknvalz;
+ 	   }else{
+	    func += ((RooAbsReal&) _coefList[ipar]).getVal()*bernknvalx*bernknvaly*bernknvalz;
 //	   std::cout<<"coeff p("<<ipar<<") = "<<((RooAbsReal&) coefList[ipar]).getVal()<<std::endl;
-	   ipar++;
+	    ipar++;
+	   }
 	  }
 	  ty*=y;
          }


### PR DESCRIPTION
This is a pull request for the following improvements:
- in utils.h: definitions of diagonal-cuts pdf shapes 
- simfit_data_fullAngularMass_Swave.cc: exponential corrected by diagonal-cuts pdf shapes for bin 3 and 5
- Fitter.h : disable optimizeConst
- RooBernsteinSideband.cxx: circularity condition
